### PR TITLE
feat: support interface method analysis for all error-handling patterns

### DIFF
--- a/goexhauerrors/analyzer.go
+++ b/goexhauerrors/analyzer.go
@@ -39,13 +39,16 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	localErrors := detectLocalErrors(pass)
 
 	// Phase 2: Analyze function bodies for returns
-	analyzeFunctionReturns(pass, localErrors)
+	localFacts, localParamFlowFacts, interfaceImpls := analyzeFunctionReturns(pass, localErrors)
 
 	// Phase 2b: Analyze closures assigned to variables
 	analyzeClosures(pass, localErrors)
 
 	// Phase 2c: Analyze errors.Is/As checks on function parameters
 	analyzeParameterErrorChecks(pass)
+
+	// Phase 2d: Compute interface method facts (after ParameterCheckedErrorsFact is available)
+	computeInterfaceMethodFacts(pass, localFacts, localParamFlowFacts, interfaceImpls)
 
 	// Phase 3: Check call sites for exhaustive errors.Is checks
 	checkCallSites(pass)

--- a/goexhauerrors/analyzer_test.go
+++ b/goexhauerrors/analyzer_test.go
@@ -34,6 +34,11 @@ func TestAnalyzer(t *testing.T) {
 		"crosspkgmethod/presentation",
 		"deferselect",
 		"funclit",
+		"ifaceparamflow",
+		"ifacechecked",
+		"crosspkgiface/iface",
+		"crosspkgiface/impl",
+		"crosspkgiface/caller",
 	)
 }
 

--- a/goexhauerrors/testdata/src/crosspkgiface/caller/caller.go
+++ b/goexhauerrors/testdata/src/crosspkgiface/caller/caller.go
@@ -1,0 +1,78 @@
+package caller
+
+import (
+	"errors"
+
+	"crosspkgiface/iface"
+	_ "crosspkgiface/impl" // import for implementation discovery
+)
+
+// =============================================================================
+// Test 1: Cross-package basic interface call — warns for all implementations' errors
+// =============================================================================
+
+func TestCrossPkgInterfaceCallBad(s iface.Service) {
+	err := s.DoWork() // want "missing errors.Is check for crosspkgiface/iface.ErrIfaceA" "missing errors.Is check for crosspkgiface/iface.ErrIfaceB"
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+func TestCrossPkgInterfaceCallPartialCheck(s iface.Service) {
+	err := s.DoWork() // want "missing errors.Is check for crosspkgiface/iface.ErrIfaceB"
+	if errors.Is(err, iface.ErrIfaceA) {
+		println("error a")
+	}
+}
+
+func TestCrossPkgInterfaceCallGood(s iface.Service) {
+	err := s.DoWork()
+	if errors.Is(err, iface.ErrIfaceA) {
+		println("error a")
+	} else if errors.Is(err, iface.ErrIfaceB) {
+		println("error b")
+	}
+}
+
+// =============================================================================
+// Test 2: Cross-package interface + ParameterFlowFact — propagation
+// =============================================================================
+
+func TestCrossPkgTransformPropagateGood(t iface.Transformer) error { // want TestCrossPkgTransformPropagateGood:`\[crosspkgiface/iface.ErrIfaceA, crosspkgiface/iface.ErrIfaceB, crosspkgiface/iface.ErrIfaceC\]` TestCrossPkgTransformPropagateGood:`\[call:0\]`
+	err := iface.GetAllErrors()
+	return t.Transform(err) // OK - all impls propagate
+}
+
+// =============================================================================
+// Test 3: Cross-package interface + ParameterCheckedErrorsFact
+// =============================================================================
+
+func TestCrossPkgMapperPartial(m iface.Mapper) error { // want TestCrossPkgMapperPartial:`\[call:0\]`
+	err := iface.GetAllErrors() // want "missing errors.Is check for crosspkgiface/iface.ErrIfaceB" "missing errors.Is check for crosspkgiface/iface.ErrIfaceC"
+	return m.Map(err) // ErrIfaceA is checked inside all impls
+}
+
+// =============================================================================
+// Test 4: Nested propagation — function returning interface method result
+// =============================================================================
+
+func intermediateFunc(s iface.Service) error { // want intermediateFunc:`\[crosspkgiface/iface.ErrIfaceA, crosspkgiface/iface.ErrIfaceB\]` intermediateFunc:`\[call:0\]`
+	err := s.DoWork()
+	return err
+}
+
+func TestNestedCrossPkgInterfaceBad(s iface.Service) {
+	err := intermediateFunc(s) // want "missing errors.Is check for crosspkgiface/iface.ErrIfaceA" "missing errors.Is check for crosspkgiface/iface.ErrIfaceB"
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+func TestNestedCrossPkgInterfaceGood(s iface.Service) {
+	err := intermediateFunc(s)
+	if errors.Is(err, iface.ErrIfaceA) {
+		println("error a")
+	} else if errors.Is(err, iface.ErrIfaceB) {
+		println("error b")
+	}
+}

--- a/goexhauerrors/testdata/src/crosspkgiface/iface/iface.go
+++ b/goexhauerrors/testdata/src/crosspkgiface/iface/iface.go
@@ -1,0 +1,41 @@
+package iface
+
+import "errors"
+
+// =============================================================================
+// Error definitions
+// =============================================================================
+
+var ErrIfaceA = errors.New("iface error a") // want ErrIfaceA:`crosspkgiface/iface.ErrIfaceA`
+var ErrIfaceB = errors.New("iface error b") // want ErrIfaceB:`crosspkgiface/iface.ErrIfaceB`
+var ErrIfaceC = errors.New("iface error c") // want ErrIfaceC:`crosspkgiface/iface.ErrIfaceC`
+
+// =============================================================================
+// Interface definitions (implementations are in separate package)
+// =============================================================================
+
+// Service is an interface whose implementations are in the impl package.
+type Service interface {
+	DoWork() error
+}
+
+// Transformer is an interface where all implementations propagate the error param.
+type Transformer interface {
+	Transform(err error) error
+}
+
+// Mapper is an interface where all implementations check ErrIfaceA.
+type Mapper interface {
+	Map(err error) error
+}
+
+// GetAllErrors is a helper that returns all errors for testing.
+func GetAllErrors() error { // want GetAllErrors:`\[crosspkgiface/iface.ErrIfaceA, crosspkgiface/iface.ErrIfaceB, crosspkgiface/iface.ErrIfaceC\]`
+	if true {
+		return ErrIfaceA
+	}
+	if true {
+		return ErrIfaceB
+	}
+	return ErrIfaceC
+}

--- a/goexhauerrors/testdata/src/crosspkgiface/impl/impl.go
+++ b/goexhauerrors/testdata/src/crosspkgiface/impl/impl.go
@@ -1,0 +1,62 @@
+package impl
+
+import (
+	"errors"
+	"fmt"
+
+	"crosspkgiface/iface"
+)
+
+// =============================================================================
+// Service implementations (DoWork returns different errors)
+// =============================================================================
+
+type ServiceImplA struct{}
+
+func (s *ServiceImplA) DoWork() error { // want DoWork:`\[crosspkgiface/iface.ErrIfaceA\]`
+	return iface.ErrIfaceA
+}
+
+type ServiceImplB struct{}
+
+func (s *ServiceImplB) DoWork() error { // want DoWork:`\[crosspkgiface/iface.ErrIfaceB\]`
+	return iface.ErrIfaceB
+}
+
+// =============================================================================
+// Transformer implementations (all propagate error param)
+// =============================================================================
+
+type TransformImplA struct{}
+
+func (t *TransformImplA) Transform(err error) error { // want Transform:`\[0\]`
+	return err
+}
+
+type TransformImplB struct{}
+
+func (t *TransformImplB) Transform(err error) error { // want Transform:`\[wrapped:0\]`
+	return fmt.Errorf("transformed: %w", err)
+}
+
+// =============================================================================
+// Mapper implementations (all check ErrIfaceA)
+// =============================================================================
+
+type MapImplA struct{}
+
+func (m *MapImplA) Map(err error) error { // want Map:`\[param0:\[crosspkgiface/iface.ErrIfaceA\]\]`
+	if errors.Is(err, iface.ErrIfaceA) {
+		return nil
+	}
+	return errors.New("not handled")
+}
+
+type MapImplB struct{}
+
+func (m *MapImplB) Map(err error) error { // want Map:`\[param0:\[crosspkgiface/iface.ErrIfaceA\]\]`
+	if errors.Is(err, iface.ErrIfaceA) {
+		return nil
+	}
+	return errors.New("not handled")
+}

--- a/goexhauerrors/testdata/src/ifacechecked/ifacechecked.go
+++ b/goexhauerrors/testdata/src/ifacechecked/ifacechecked.go
@@ -1,0 +1,123 @@
+package ifacechecked
+
+import "errors"
+
+// =============================================================================
+// Error definitions
+// =============================================================================
+
+var ErrC1 = errors.New("c1") // want ErrC1:`ifacechecked.ErrC1`
+var ErrC2 = errors.New("c2") // want ErrC2:`ifacechecked.ErrC2`
+var ErrC3 = errors.New("c3") // want ErrC3:`ifacechecked.ErrC3`
+
+func getMultiErr() error { // want getMultiErr:`\[ifacechecked.ErrC1, ifacechecked.ErrC2, ifacechecked.ErrC3\]`
+	if true {
+		return ErrC1
+	}
+	if true {
+		return ErrC2
+	}
+	return ErrC3
+}
+
+// =============================================================================
+// Interface where ALL implementations check ErrC1 (but do NOT propagate)
+// =============================================================================
+
+type Checker interface {
+	Check(err error) error // want Check:`\[param0:\[ifacechecked.ErrC1\]\]`
+}
+
+type CheckImpl1 struct{}
+
+func (c *CheckImpl1) Check(err error) error { // want Check:`\[param0:\[ifacechecked.ErrC1\]\]`
+	if errors.Is(err, ErrC1) {
+		return nil
+	}
+	return errors.New("unhandled")
+}
+
+type CheckImpl2 struct{}
+
+func (c *CheckImpl2) Check(err error) error { // want Check:`\[param0:\[ifacechecked.ErrC1\]\]`
+	if errors.Is(err, ErrC1) {
+		return nil
+	}
+	return errors.New("unhandled")
+}
+
+// Test: ErrC1 is checked by all impls inside Check, so only ErrC2 and ErrC3 should be warned
+func TestCheckedViaInterfacePartial(c Checker) error { // want TestCheckedViaInterfacePartial:`\[call:0\]`
+	err := getMultiErr() // want "missing errors.Is check for ifacechecked.ErrC2" "missing errors.Is check for ifacechecked.ErrC3"
+	return c.Check(err)
+}
+
+// =============================================================================
+// Interface where implementations check DIFFERENT errors (no intersection)
+// =============================================================================
+
+type DivergentChecker interface {
+	DivCheck(err error) error
+}
+
+type DivImpl1 struct{}
+
+func (d *DivImpl1) DivCheck(err error) error { // want DivCheck:`\[param0:\[ifacechecked.ErrC1\]\]`
+	if errors.Is(err, ErrC1) {
+		return nil
+	}
+	return errors.New("unhandled")
+}
+
+type DivImpl2 struct{}
+
+func (d *DivImpl2) DivCheck(err error) error { // want DivCheck:`\[param0:\[ifacechecked.ErrC2\]\]`
+	if errors.Is(err, ErrC2) {
+		return nil
+	}
+	return errors.New("unhandled")
+}
+
+// Test: different errors checked in different impls → intersection is empty → all warned
+func TestDivergentCheckedBad(d DivergentChecker) error { // want TestDivergentCheckedBad:`\[call:0\]`
+	err := getMultiErr() // want "missing errors.Is check for ifacechecked.ErrC1" "missing errors.Is check for ifacechecked.ErrC2" "missing errors.Is check for ifacechecked.ErrC3"
+	return d.DivCheck(err)
+}
+
+// =============================================================================
+// Interface where ALL implementations check ErrC1 and ErrC2
+// =============================================================================
+
+type FullChecker interface {
+	FullCheck(err error) error // want FullCheck:`\[param0:\[ifacechecked.ErrC1,ifacechecked.ErrC2\]\]`
+}
+
+type FullImpl1 struct{}
+
+func (f *FullImpl1) FullCheck(err error) error { // want FullCheck:`\[param0:\[ifacechecked.ErrC1,ifacechecked.ErrC2\]\]`
+	if errors.Is(err, ErrC1) {
+		return nil
+	}
+	if errors.Is(err, ErrC2) {
+		return nil
+	}
+	return errors.New("unhandled")
+}
+
+type FullImpl2 struct{}
+
+func (f *FullImpl2) FullCheck(err error) error { // want FullCheck:`\[param0:\[ifacechecked.ErrC1,ifacechecked.ErrC2\]\]`
+	if errors.Is(err, ErrC1) {
+		return nil
+	}
+	if errors.Is(err, ErrC2) {
+		return nil
+	}
+	return errors.New("unhandled")
+}
+
+// Test: ErrC1 and ErrC2 are checked by all impls → only ErrC3 warned
+func TestFullCheckedViaInterface(fc FullChecker) error { // want TestFullCheckedViaInterface:`\[call:0\]`
+	err := getMultiErr() // want "missing errors.Is check for ifacechecked.ErrC3"
+	return fc.FullCheck(err)
+}

--- a/goexhauerrors/testdata/src/ifaceparamflow/ifaceparamflow.go
+++ b/goexhauerrors/testdata/src/ifaceparamflow/ifaceparamflow.go
@@ -1,0 +1,118 @@
+package ifaceparamflow
+
+import (
+	"errors"
+	"fmt"
+)
+
+// =============================================================================
+// Error definitions
+// =============================================================================
+
+var ErrPF1 = errors.New("pf1") // want ErrPF1:`ifaceparamflow.ErrPF1`
+var ErrPF2 = errors.New("pf2") // want ErrPF2:`ifaceparamflow.ErrPF2`
+
+func getErr() error { // want getErr:`\[ifaceparamflow.ErrPF1\]`
+	return ErrPF1
+}
+
+func getMultiErr() error { // want getMultiErr:`\[ifaceparamflow.ErrPF1, ifaceparamflow.ErrPF2\]`
+	if true {
+		return ErrPF1
+	}
+	return ErrPF2
+}
+
+// =============================================================================
+// Interface where ALL implementations propagate error parameter
+// =============================================================================
+
+type Propagator interface {
+	Propagate(err error) error // want Propagate:`\[0\]`
+}
+
+type PropImpl1 struct{}
+
+func (p *PropImpl1) Propagate(err error) error { // want Propagate:`\[0\]`
+	return err
+}
+
+type PropImpl2 struct{}
+
+func (p *PropImpl2) Propagate(err error) error { // want Propagate:`\[0\]`
+	return err
+}
+
+// Test: propagation through interface should be OK (all impls propagate)
+func TestPropagateViaInterfaceGood(p Propagator) error { // want TestPropagateViaInterfaceGood:`\[ifaceparamflow.ErrPF1\]` TestPropagateViaInterfaceGood:`\[call:0\]`
+	err := getErr()
+	return p.Propagate(err) // OK - all impls propagate
+}
+
+// Test: propagation through interface with multiple errors should also propagate
+func TestPropagateMultiGood(p Propagator) error { // want TestPropagateMultiGood:`\[ifaceparamflow.ErrPF1, ifaceparamflow.ErrPF2\]` TestPropagateMultiGood:`\[call:0\]`
+	err := getMultiErr()
+	return p.Propagate(err) // OK - all impls propagate
+}
+
+// =============================================================================
+// Interface where NOT all implementations propagate
+// =============================================================================
+
+type PartialPropagator interface {
+	MaybePropagate(err error) error
+}
+
+type PartialImpl1 struct{}
+
+func (p *PartialImpl1) MaybePropagate(err error) error { // want MaybePropagate:`\[0\]`
+	return err
+}
+
+type PartialImpl2 struct{}
+
+func (p *PartialImpl2) MaybePropagate(err error) error {
+	return errors.New("replaced")
+}
+
+// Test: should warn because not all impls propagate
+func TestPartialPropagateBad(p PartialPropagator) error { // want TestPartialPropagateBad:`\[call:0\]`
+	err := getErr() // want "missing errors.Is check for ifaceparamflow.ErrPF1"
+	return p.MaybePropagate(err)
+}
+
+// =============================================================================
+// Interface where all implementations wrap with %w
+// =============================================================================
+
+type Wrapper interface {
+	Wrap(err error) error // want Wrap:`\[wrapped:0\]`
+}
+
+type WrapImpl1 struct{}
+
+func (w *WrapImpl1) Wrap(err error) error { // want Wrap:`\[wrapped:0\]`
+	return fmt.Errorf("impl1: %w", err)
+}
+
+type WrapImpl2 struct{}
+
+func (w *WrapImpl2) Wrap(err error) error { // want Wrap:`\[wrapped:0\]`
+	return fmt.Errorf("impl2: %w", err)
+}
+
+// Test: wrapping propagation through interface should be OK
+func TestWrapViaInterfaceGood(w Wrapper) error { // want TestWrapViaInterfaceGood:`\[ifaceparamflow.ErrPF1\]` TestWrapViaInterfaceGood:`\[call:0\]`
+	err := getErr()
+	return w.Wrap(err) // OK - all impls wrap with %w
+}
+
+// =============================================================================
+// Concrete type still detected normally alongside interface
+// =============================================================================
+
+func TestConcreteStillWorks() error { // want TestConcreteStillWorks:`\[ifaceparamflow.ErrPF1\]`
+	p := &PropImpl1{}
+	err := getErr()
+	return p.Propagate(err) // OK - concrete propagation
+}


### PR DESCRIPTION
## Summary

- **Cross-package interface resolution**: `findInterfaceImplementations` now scans imported packages, enabling error detection through interfaces defined in other packages
- **ParameterFlowFact on interface methods**: When ALL implementations propagate an error parameter, the interface method itself is recognized as propagating (intersection semantics), so callers don't get false-positive warnings
- **ParameterCheckedErrorsFact on interface methods**: When ALL implementations check a specific error with `errors.Is/As`, that error is considered handled when passed through the interface method (intersection semantics)
- **SSA-level ParameterFlowFact resolution**: Both invoke (interface) and static (concrete) calls now resolve errors flowing through parameters via `ParameterFlowFact`
- **Callsite fallback for cross-package interfaces**: Dynamically computes intersection of `ParameterFlowFact` and `ParameterCheckedErrorsFact` from implementations when facts aren't available on the interface method itself
- **Phase ordering fix**: `computeInterfaceMethodFacts` now runs after `analyzeParameterErrorChecks` so that `ParameterCheckedErrorsFact` is available for interface method fact computation

### Patterns now supported

| Pattern | Description |
|---------|-------------|
| Cross-package basic interface call | Warns for all implementations' errors across packages |
| Cross-package multiple implementations union | Union of errors from all implementations |
| Interface + ParameterFlowFact | Error propagation recognized through interface methods |
| Interface + ParameterCheckedErrorsFact | errors.Is/As checks inside implementations reduce warnings |
| Nested propagation via cross-package interface | Functions returning interface method results propagate errors |

## Test plan

- [x] New test package `ifaceparamflow`: same-package interface + ParameterFlowFact (all/partial propagation, wrapping)
- [x] New test package `ifacechecked`: same-package interface + ParameterCheckedErrorsFact (full/partial/divergent checking)
- [x] New test package `crosspkgiface`: cross-package tests for basic calls, ParameterFlowFact, ParameterCheckedErrorsFact, and nested propagation
- [x] All existing tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)