### PR TITLE
fix: propagate visited map and depth in parameter flow error tracing

### DIFF
--- a/goexhauerrors/callsite.go
+++ b/goexhauerrors/callsite.go
@@ -977,7 +977,7 @@ func resolveFlowErrors(pass *analysis.Pass, call *ast.CallExpr, flows []flowInfo
 	var errs []ErrorInfo
 
 	for _, flow := range flows {
-		if flow.Index() >= len(call.Args) {
+		if flow.Index() < 0 || flow.Index() >= len(call.Args) {
 			continue
 		}
 


### PR DESCRIPTION
## Summary

- Propagate `visited` map and `depth` through `getErrorsFromCall`, `getErrorsFromInvoke`, and parameter flow resolution functions to prevent infinite recursion and duplicate error tracing in nested call chains
- Add bounds check for negative flow index in `resolveFlowErrors` to avoid out-of-bounds access
- Add bounds check for negative adjusted parameter index in `detectParameterFlow` and `detectFunctionParamCallFlow` to prevent underflow when receiver offset exceeds param index

## Test plan

- [ ] Run existing analyzer tests to verify no regressions
- [ ] Verify that nested/recursive call chains no longer cause infinite loops or duplicate errors
- [ ] Verify that methods with receiver parameters are handled correctly without negative index panics

🤖 Generated with [Claude Code](https://claude.com/claude-code)