### PR TITLE
fix: suppress false positives for unexported errors from external packages

### DIFF
--- a/goexhauerrors/analyzer_test.go
+++ b/goexhauerrors/analyzer_test.go
@@ -39,6 +39,8 @@ func TestAnalyzer(t *testing.T) {
 		"crosspkgiface/iface",
 		"crosspkgiface/impl",
 		"crosspkgiface/caller",
+		"crosspkgunexported/errors",
+		"crosspkgunexported/caller",
 	)
 }
 

--- a/goexhauerrors/checker/checker.go
+++ b/goexhauerrors/checker/checker.go
@@ -629,6 +629,11 @@ func reportUncheckedErrors(pass *analysis.Pass, state *errorVarState) {
 		if internal.ShouldIgnorePackage(errInfo.PkgPath) {
 			continue
 		}
+		// Skip unexported errors from other packages.
+		// These cannot be checked with errors.Is/errors.As from outside the package.
+		if errInfo.PkgPath != pass.Pkg.Path() && !token.IsExported(errInfo.Name) {
+			continue
+		}
 		key := errInfo.Key()
 		if !state.checked[key] {
 			pass.Reportf(state.callPos, "missing errors.Is check for %s", key)

--- a/goexhauerrors/testdata/src/crosspkgunexported/caller/caller.go
+++ b/goexhauerrors/testdata/src/crosspkgunexported/caller/caller.go
@@ -1,0 +1,40 @@
+package caller
+
+import (
+	"errors"
+
+	cpkgerrors "crosspkgunexported/errors"
+)
+
+// --- Cross-package callers: unexported errors should NOT be detected ---
+
+// BadCallerMixed calls a function returning both exported and unexported errors.
+// Only exported errors should be warned - unexported errors from other packages
+// cannot be checked with errors.Is/errors.As.
+func BadCallerMixed() {
+	err := cpkgerrors.DoWork(1) // want "missing errors.Is check for crosspkgunexported/errors.ErrPublic" "missing errors.Is check for crosspkgunexported/errors.PublicError"
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+// BadCallerPrivateOnly calls a function returning only unexported errors.
+// No warnings should be emitted since none of the errors can be checked from outside.
+func BadCallerPrivateOnly() {
+	err := cpkgerrors.DoPrivateWork()
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+// GoodCallerMixed properly checks the exported errors - no warning.
+func GoodCallerMixed() {
+	err := cpkgerrors.DoWork(1)
+	if errors.Is(err, cpkgerrors.ErrPublic) {
+		println("public sentinel")
+	}
+	var pubErr *cpkgerrors.PublicError
+	if errors.As(err, &pubErr) {
+		println("public error type")
+	}
+}

--- a/goexhauerrors/testdata/src/crosspkgunexported/errors/errors.go
+++ b/goexhauerrors/testdata/src/crosspkgunexported/errors/errors.go
@@ -1,0 +1,86 @@
+package errors
+
+import "errors"
+
+// Exported sentinel error
+var ErrPublic = errors.New("public error") // want ErrPublic:`crosspkgunexported/errors.ErrPublic`
+
+// Unexported sentinel error - tracked locally but not exported as ErrorFact
+var errPrivate = errors.New("private error")
+
+// Unexported custom error type
+type internalError struct {
+	msg string
+}
+
+func (e *internalError) Error() string {
+	return e.msg
+}
+
+// Exported custom error type
+type PublicError struct { // want PublicError:`crosspkgunexported/errors.PublicError`
+	Msg string
+}
+
+func (e *PublicError) Error() string {
+	return e.Msg
+}
+
+// Function returning both exported and unexported errors
+func DoWork(flag int) error { // want DoWork:`\[crosspkgunexported/errors.ErrPublic, crosspkgunexported/errors.PublicError, crosspkgunexported/errors.errPrivate, crosspkgunexported/errors.internalError\]`
+	switch flag {
+	case 1:
+		return ErrPublic
+	case 2:
+		return &PublicError{Msg: "pub"}
+	case 3:
+		return errPrivate
+	default:
+		return &internalError{msg: "internal"}
+	}
+}
+
+// Function returning only unexported errors
+func DoPrivateWork() error { // want DoPrivateWork:`\[crosspkgunexported/errors.errPrivate, crosspkgunexported/errors.internalError\]`
+	if true {
+		return errPrivate
+	}
+	return &internalError{msg: "internal"}
+}
+
+// --- Same-package callers: unexported errors SHOULD be detected ---
+
+// SamePackageBadCallerMixed does not check any errors - should warn about all (exported + unexported)
+func SamePackageBadCallerMixed() {
+	err := DoWork(1) // want "missing errors.Is check for crosspkgunexported/errors.ErrPublic" "missing errors.Is check for crosspkgunexported/errors.PublicError" "missing errors.Is check for crosspkgunexported/errors.errPrivate" "missing errors.Is check for crosspkgunexported/errors.internalError"
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+// SamePackageBadCallerPrivateOnly does not check unexported errors - should warn
+func SamePackageBadCallerPrivateOnly() {
+	err := DoPrivateWork() // want "missing errors.Is check for crosspkgunexported/errors.errPrivate" "missing errors.Is check for crosspkgunexported/errors.internalError"
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+// SamePackageGoodCaller checks all errors including unexported - no warning
+func SamePackageGoodCaller() {
+	err := DoWork(1)
+	if errors.Is(err, ErrPublic) {
+		println("public sentinel")
+	}
+	var pubErr *PublicError
+	if errors.As(err, &pubErr) {
+		println("public error type")
+	}
+	if errors.Is(err, errPrivate) {
+		println("private sentinel")
+	}
+	var intErr *internalError
+	if errors.As(err, &intErr) {
+		println("internal error type")
+	}
+}


### PR DESCRIPTION
## Summary

- Unexported error types (e.g. `uuid.invalidLengthError`) from external packages cannot be checked with `errors.Is`/`errors.As` by callers outside the package, but the linter was incorrectly reporting warnings for them
- Added a filter in `reportUncheckedErrors` to skip unexported errors when the caller is in a different package
- Same-package callers still get warnings for unexported errors, since they have direct access to those symbols

## Test plan

- [ ] `crosspkgunexported/errors`: same-package callers detect both exported and unexported errors
- [ ] `crosspkgunexported/caller`: cross-package callers detect only exported errors, no false positives for unexported ones
- [ ] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)