### PR TITLE
Fix false negative: propagate higher-order function errors through wrapper functions

### DIFF
--- a/goexhauerrors/analyzer/analyzer.go
+++ b/goexhauerrors/analyzer/analyzer.go
@@ -75,7 +75,7 @@ func AnalyzeFunctionReturns(pass *analysis.Pass, localErrs *detector.LocalErrors
 		changed := false
 
 		// Create SSA analyzer with current local facts
-		ssaAnalyzer := ssaanalysis.NewAnalyzer(pass, localErrs, localFacts, localParamFlowFacts, interfaceImpls)
+		ssaAnalyzer := ssaanalysis.NewAnalyzer(pass, localErrs, localFacts, localParamFlowFacts, localCallFlowFacts, interfaceImpls)
 
 		for _, fi := range funcs {
 			// Phase A: Detect parameter flow (for error-typed parameters)

--- a/goexhauerrors/checker/checker.go
+++ b/goexhauerrors/checker/checker.go
@@ -1011,6 +1011,13 @@ func extractErrorsFromExpr(pass *analysis.Pass, expr ast.Expr) []facts.ErrorInfo
 				errs = append(errs, fnFact.Errors...)
 			}
 		}
+		// Also check for named functions (e.g., passing namedFunc to a higher-order function)
+		if funcObj, ok := obj.(*types.Func); ok {
+			var fnFact facts.FunctionErrorsFact
+			if pass.ImportObjectFact(funcObj, &fnFact) {
+				errs = append(errs, fnFact.Errors...)
+			}
+		}
 
 	case *ast.SelectorExpr:
 		obj := pass.TypesInfo.Uses[e.Sel]
@@ -1022,6 +1029,13 @@ func extractErrorsFromExpr(pass *analysis.Pass, expr ast.Expr) []facts.ErrorInfo
 					Name:    errorFact.Name,
 					Wrapped: false,
 				})
+			}
+		}
+		// Also check for named functions (e.g., passing pkg.NamedFunc to a higher-order function)
+		if funcObj, ok := obj.(*types.Func); ok {
+			var fnFact facts.FunctionErrorsFact
+			if pass.ImportObjectFact(funcObj, &fnFact) {
+				errs = append(errs, fnFact.Errors...)
 			}
 		}
 

--- a/goexhauerrors/testdata/src/crosspkg/caller/caller.go
+++ b/goexhauerrors/testdata/src/crosspkg/caller/caller.go
@@ -35,6 +35,34 @@ func BadCallerBoth() {
 	}
 }
 
+func BadCallerHigherOrder() {
+	err := middle.PropagateViaHigherOrderNamedFunc() // want "missing errors.Is check for crosspkg/errors.ErrCrossPkg"
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+func BadCallerDirectNamedFunc() {
+	err := cpkgerrors.RunWithCallback(cpkgerrors.GetError) // want "missing errors.Is check for crosspkg/errors.ErrCrossPkg"
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+func GoodCallerDirectNamedFunc() {
+	err := cpkgerrors.RunWithCallback(cpkgerrors.GetError)
+	if errors.Is(err, cpkgerrors.ErrCrossPkg) {
+		println("cross pkg error")
+	}
+}
+
+func GoodCallerHigherOrder() {
+	err := middle.PropagateViaHigherOrderNamedFunc()
+	if errors.Is(err, cpkgerrors.ErrCrossPkg) {
+		println("cross pkg error")
+	}
+}
+
 func GoodCaller() {
 	err := middle.PropagateViaVar()
 	if errors.Is(err, cpkgerrors.ErrCrossPkg) {

--- a/goexhauerrors/testdata/src/crosspkg/errors/errors.go
+++ b/goexhauerrors/testdata/src/crosspkg/errors/errors.go
@@ -19,3 +19,8 @@ func GetError() error { // want GetError:`\[crosspkg/errors.ErrCrossPkg\]`
 func GetCustomError() error { // want GetCustomError:`\[crosspkg/errors.CrossPkgError\]`
 	return &CrossPkgError{Code: 500}
 }
+
+// RunWithCallback is a higher-order function that calls the provided function.
+func RunWithCallback(fn func() error) error { // want RunWithCallback:`\[call:0\]`
+	return fn()
+}

--- a/goexhauerrors/testdata/src/crosspkg/middle/middle.go
+++ b/goexhauerrors/testdata/src/crosspkg/middle/middle.go
@@ -26,6 +26,13 @@ func PropagateDirectReturn() error { // want PropagateDirectReturn:`\[crosspkg/e
 	return cpkgerrors.GetError()
 }
 
+// PropagateViaHigherOrderNamedFunc wraps a cross-package higher-order function call
+// with a named function argument. The errors from the named function should propagate
+// through the FunctionParamCallFlowFact of RunWithCallback.
+func PropagateViaHigherOrderNamedFunc() error { // want PropagateViaHigherOrderNamedFunc:`\[crosspkg/errors.ErrCrossPkg\]`
+	return cpkgerrors.RunWithCallback(cpkgerrors.GetError)
+}
+
 // PropagateBothViaVar propagates both sentinel and custom error
 func PropagateBothViaVar(useCustom bool) error { // want PropagateBothViaVar:`\[crosspkg/errors.CrossPkgError, crosspkg/errors.ErrCrossPkg\]`
 	var err error

--- a/goexhauerrors/testdata/src/higherorder/higherorder_wrapper.go
+++ b/goexhauerrors/testdata/src/higherorder/higherorder_wrapper.go
@@ -1,0 +1,166 @@
+package higherorder
+
+import (
+	"context"
+	"errors"
+)
+
+// =============================================================================
+// Test: Named function passed to higher-order function
+// This is the core case for issue #12 - named functions don't get their
+// errors propagated through FunctionParamCallFlowFact in Phase 2
+// =============================================================================
+
+func namedTxFunc(tx Tx) error { // want namedTxFunc:`\[higherorder.ErrNotFound\]`
+	return ErrNotFound
+}
+
+func wrapperWithNamedFunc() error { // want wrapperWithNamedFunc:`\[higherorder.ErrNotFound\]`
+	conn := &Conn{}
+	return conn.RunInTx(context.Background(), namedTxFunc)
+}
+
+// =============================================================================
+// Test: Named function passed DIRECTLY to higher-order function at call site
+// This tests Phase 3 checker's extractErrorsFromExpr handling of *types.Func
+// =============================================================================
+
+func TestDirectNamedFunc() {
+	conn := &Conn{}
+	ctx := context.Background()
+	err := conn.RunInTx(ctx, namedTxFunc) // want "missing errors.Is check for higherorder.ErrNotFound"
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+func TestDirectNamedFuncGood() {
+	conn := &Conn{}
+	ctx := context.Background()
+	err := conn.RunInTx(ctx, namedTxFunc)
+	if errors.Is(err, ErrNotFound) {
+		println("not found")
+	}
+}
+
+func TestWrapperWithNamedFunc() {
+	err := wrapperWithNamedFunc() // want "missing errors.Is check for higherorder.ErrNotFound"
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+func TestWrapperWithNamedFuncGood() {
+	err := wrapperWithNamedFunc()
+	if errors.Is(err, ErrNotFound) {
+		println("not found")
+	}
+}
+
+// =============================================================================
+// Test: Closure variable passed to higher-order function
+// Note: This case already works via AST path (ast.Inspect traverses into
+// the inline closure body). Included here for completeness.
+// =============================================================================
+
+func wrapperWithClosureVar() error { // want wrapperWithClosureVar:`\[higherorder.ErrNotFound\]`
+	txFunc := func(tx Tx) error { // want txFunc:`\[higherorder.ErrNotFound\]`
+		return ErrNotFound
+	}
+	conn := &Conn{}
+	return conn.RunInTx(context.Background(), txFunc)
+}
+
+func TestWrapperWithClosureVar() {
+	err := wrapperWithClosureVar() // want "missing errors.Is check for higherorder.ErrNotFound"
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+func TestWrapperWithClosureVarGood() {
+	err := wrapperWithClosureVar()
+	if errors.Is(err, ErrNotFound) {
+		println("not found")
+	}
+}
+
+// =============================================================================
+// Test: Named function with multiple errors passed to higher-order function
+// =============================================================================
+
+func namedTxFuncMultiple(tx Tx) error { // want namedTxFuncMultiple:`\[higherorder.ErrNotFound, higherorder.ErrUpdate\]`
+	if true {
+		return ErrNotFound
+	}
+	return ErrUpdate
+}
+
+func wrapperWithNamedFuncMultiple() error { // want wrapperWithNamedFuncMultiple:`\[higherorder.ErrNotFound, higherorder.ErrUpdate\]`
+	conn := &Conn{}
+	return conn.RunInTx(context.Background(), namedTxFuncMultiple)
+}
+
+func TestWrapperWithNamedFuncMultiple() {
+	err := wrapperWithNamedFuncMultiple() // want "missing errors.Is check for higherorder.ErrNotFound" "missing errors.Is check for higherorder.ErrUpdate"
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+func TestWrapperWithNamedFuncMultipleGood() {
+	err := wrapperWithNamedFuncMultiple()
+	if errors.Is(err, ErrNotFound) {
+		println("not found")
+	} else if errors.Is(err, ErrUpdate) {
+		println("update failed")
+	}
+}
+
+// =============================================================================
+// Test: Named function passed to non-method higher-order function
+// =============================================================================
+
+func namedCallbackFunc() error { // want namedCallbackFunc:`\[higherorder.ErrNotFound\]`
+	return ErrNotFound
+}
+
+func wrapperWithNamedCallback() error { // want wrapperWithNamedCallback:`\[higherorder.ErrNotFound\]`
+	return RunWithCallback(namedCallbackFunc)
+}
+
+func TestWrapperWithNamedCallback() {
+	err := wrapperWithNamedCallback() // want "missing errors.Is check for higherorder.ErrNotFound"
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+func TestWrapperWithNamedCallbackGood() {
+	err := wrapperWithNamedCallback()
+	if errors.Is(err, ErrNotFound) {
+		println("not found")
+	}
+}
+
+// =============================================================================
+// Test: Two-level wrapper with named function
+// =============================================================================
+
+func outerWrapperNamedFunc() error { // want outerWrapperNamedFunc:`\[higherorder.ErrNotFound\]`
+	return wrapperWithNamedFunc()
+}
+
+func TestOuterWrapperNamedFunc() {
+	err := outerWrapperNamedFunc() // want "missing errors.Is check for higherorder.ErrNotFound"
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+func TestOuterWrapperNamedFuncGood() {
+	err := outerWrapperNamedFunc()
+	if errors.Is(err, ErrNotFound) {
+		println("not found")
+	}
+}


### PR DESCRIPTION
## Summary

- Resolve false negatives where errors from function arguments passed to higher-order functions (e.g., `db.Update(fn)`) were not included in the wrapper function's `FunctionErrorsFact`, causing callers to see no errors to check
- Add `FunctionParamCallFlowFact` resolution in SSA `getErrorsFromCall` so Phase 2 correctly traces errors from named functions passed to higher-order functions
- Add `*types.Func` handling in checker `extractErrorsFromExpr` for both `*ast.Ident` and `*ast.SelectorExpr` so Phase 3 correctly resolves named function arguments at direct call sites (same-package and cross-package)

## Test plan

- [x] New same-package tests: named function, closure variable, multiple errors, non-method higher-order function, two-level wrapper
- [x] New cross-package tests: named function passed through wrapper, named function passed directly to higher-order function
- [x] All existing tests pass (`go test ./...`)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)