### PR TITLE
fix: prevent false negatives from switch branch propagation

### DIFF
--- a/goexhauerrors/checker/checker_test.go
+++ b/goexhauerrors/checker/checker_test.go
@@ -79,3 +79,8 @@ func TestCheckerPartial(t *testing.T) {
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, testAnalyzer, "partial")
 }
+
+func TestCheckerSwitchPropagation(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, testAnalyzer, "switch_propagation")
+}

--- a/goexhauerrors/checker/testdata/src/switch_propagation/switch_propagation.go
+++ b/goexhauerrors/checker/testdata/src/switch_propagation/switch_propagation.go
@@ -1,0 +1,125 @@
+package switch_propagation
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrA = errors.New("a") // want ErrA:`switch_propagation.ErrA`
+var ErrB = errors.New("b") // want ErrB:`switch_propagation.ErrB`
+var ErrC = errors.New("c") // want ErrC:`switch_propagation.ErrC`
+
+func ThreeErrors(id string) error { // want ThreeErrors:`\[switch_propagation.ErrA, switch_propagation.ErrB, switch_propagation.ErrC\]`
+	switch id {
+	case "a":
+		return ErrA
+	case "b":
+		return ErrB
+	case "c":
+		return ErrC
+	}
+	return nil
+}
+
+// SwitchPropagationFalseNegative: ErrA and ErrB are checked with errors.Is
+// and propagated via return err. ErrC falls into the catch-all branch where
+// its identity is lost via fmt.Errorf with %v. Should report ErrC as unchecked.
+func SwitchPropagationFalseNegative() (int, error) { // want SwitchPropagationFalseNegative:`\[switch_propagation.ErrA, switch_propagation.ErrB, switch_propagation.ErrC\]`
+	err := ThreeErrors("x") // want "missing errors.Is check for switch_propagation.ErrC"
+	switch {
+	case errors.Is(err, ErrA) || errors.Is(err, ErrB):
+		return 1, err
+	case err != nil:
+		return 0, fmt.Errorf("unexpected: %v", err)
+	}
+	return 0, nil
+}
+
+// SwitchPropagationAllChecked: All errors are checked with errors.Is and
+// propagated. No diagnostic expected.
+func SwitchPropagationAllChecked() (int, error) { // want SwitchPropagationAllChecked:`\[switch_propagation.ErrA, switch_propagation.ErrB, switch_propagation.ErrC\]`
+	err := ThreeErrors("x")
+	switch {
+	case errors.Is(err, ErrA) || errors.Is(err, ErrB):
+		return 1, err
+	case errors.Is(err, ErrC):
+		return 2, err
+	}
+	return 0, nil
+}
+
+// SwitchPropagationCatchAllReturn: All branches propagate the error.
+// The catch-all case uses return err directly, so all errors are propagated.
+// No diagnostic expected.
+func SwitchPropagationCatchAllReturn() (int, error) { // want SwitchPropagationCatchAllReturn:`\[switch_propagation.ErrA, switch_propagation.ErrB, switch_propagation.ErrC\]`
+	err := ThreeErrors("x")
+	switch {
+	case errors.Is(err, ErrA):
+		return 1, err
+	case err != nil:
+		return 0, err
+	}
+	return 0, nil
+}
+
+// SwitchPropagationSingleCheck: Only ErrA is checked and propagated.
+// ErrB and ErrC are unchecked.
+func SwitchPropagationSingleCheck() (int, error) { // want SwitchPropagationSingleCheck:`\[switch_propagation.ErrA, switch_propagation.ErrB, switch_propagation.ErrC\]`
+	err := ThreeErrors("x") // want "missing errors.Is check for switch_propagation.ErrB" "missing errors.Is check for switch_propagation.ErrC"
+	switch {
+	case errors.Is(err, ErrA):
+		return 1, err
+	case err != nil:
+		return 0, fmt.Errorf("unexpected: %v", err)
+	}
+	return 0, nil
+}
+
+// SwitchTagPropagation: Only ErrA is properly checked and propagated.
+// ErrB and ErrC should be reported.
+func SwitchTagPropagation() (int, error) { // want SwitchTagPropagation:`\[switch_propagation.ErrA, switch_propagation.ErrB, switch_propagation.ErrC\]`
+	err := ThreeErrors("x") // want "missing errors.Is check for switch_propagation.ErrB" "missing errors.Is check for switch_propagation.ErrC"
+	switch {
+	case errors.Is(err, ErrA):
+		return 1, err
+	}
+	return 0, nil
+}
+
+// SwitchPropagationWithWrap: ErrA is checked and wrapped with %w (propagated).
+// ErrB and ErrC fall into catch-all with %v (not propagated).
+func SwitchPropagationWithWrap() (int, error) {
+	err := ThreeErrors("x") // want "missing errors.Is check for switch_propagation.ErrB" "missing errors.Is check for switch_propagation.ErrC"
+	switch {
+	case errors.Is(err, ErrA):
+		return 1, fmt.Errorf("wrapped: %w", err)
+	case err != nil:
+		return 0, fmt.Errorf("unexpected: %v", err)
+	}
+	return 0, nil
+}
+
+// SwitchTagWithPropagation: switch err { case ErrA: return err } syntax.
+// Only ErrA is checked via direct comparison and propagated.
+// ErrB and ErrC should be reported.
+func SwitchTagWithPropagation() (int, error) { // want SwitchTagWithPropagation:`\[switch_propagation.ErrA, switch_propagation.ErrB, switch_propagation.ErrC\]`
+	err := ThreeErrors("x") // want "missing errors.Is check for switch_propagation.ErrB" "missing errors.Is check for switch_propagation.ErrC"
+	switch err {
+	case ErrA:
+		return 1, err
+	default:
+		return 0, fmt.Errorf("unexpected: %v", err)
+	}
+}
+
+// SwitchDefaultPropagation: default clause propagates, so all errors are propagated.
+// No diagnostic expected because the default clause is a catch-all and directly returns err.
+func SwitchDefaultPropagation() (int, error) { // want SwitchDefaultPropagation:`\[switch_propagation.ErrA, switch_propagation.ErrB, switch_propagation.ErrC\]`
+	err := ThreeErrors("x")
+	switch {
+	case errors.Is(err, ErrA):
+		return 1, err
+	default:
+		return 0, err
+	}
+}


### PR DESCRIPTION
## Summary

- Fix false negatives where `return err` inside a switch case with `errors.Is` narrowing incorrectly marked **all** tracked errors as checked, instead of only the narrowed ones
- Scope `collectErrorsIsInExpr` to cloned case states so case condition checks don't leak across cases
- Apply the same fix to both `SwitchStmt` and `TypeSwitchStmt`

Closes #10

## Root Cause

Two compounding issues in `checker.go`:

1. **`collectErrorsIsInExpr` applied to main states (not case-scoped):** Case condition checks (`errors.Is`) were applied to the shared parent state before cloning, polluting subsequent cases.
2. **`ReturnStmt` propagation marked all errors:** When `return err` was encountered inside a switch case, all errors in `state.errors` were marked as checked regardless of which branch narrowed the error.

The combination meant: if **any** switch branch propagated the error, **all** errors were treated as checked after the switch.

## Changes

### `errorVarState.propagatableKeys` (new field)
When set, limits which errors can be propagated via `return`. If `nil`, all errors are propagatable (preserving existing behavior for non-switch contexts and catch-all cases like `case err != nil:` or `default:`).

### `applyPropagationNarrowing()` (new helper)
Computes the set of errors newly checked by a case condition (diff between case state and parent state). Sets `propagatableKeys` on the case state so that `return err` in the case body only propagates those narrowed errors.

### Switch case handling
- Clone states **before** applying case condition checks (scoping them to the case branch)
- Call `applyPropagationNarrowing` before walking the case body

### `ReturnStmt` handling
- Respects `propagatableKeys`: only marks propagatable errors as checked

### `cloneStates`
- Deep-copies `propagatableKeys`

## Test plan

- [x] `SwitchPropagationFalseNegative` — the exact pattern from the issue (`errors.Is` + `return err` in one case, catch-all loses identity with `%v`)
- [x] `SwitchPropagationAllChecked` — all errors checked with `errors.Is` and propagated (no diagnostic)
- [x] `SwitchPropagationCatchAllReturn` — catch-all uses `return err` directly (no diagnostic)
- [x] `SwitchPropagationSingleCheck` — only one error checked, others unchecked
- [x] `SwitchTagPropagation` — single `errors.Is` case with propagation, no other cases
- [x] `SwitchPropagationWithWrap` — `fmt.Errorf("%w")` in narrowed case, `%v` in catch-all
- [x] `SwitchTagWithPropagation` — `switch err { case ErrA: return err }` syntax with `default:` catch-all
- [x] `SwitchDefaultPropagation` — `default:` clause propagates directly (no diagnostic)
- [x] All existing tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)