### PR TITLE
fix: detect composite literal sentinel errors declared as error interface type

### DIFF
--- a/goexhauerrors/analyzer_test.go
+++ b/goexhauerrors/analyzer_test.go
@@ -45,7 +45,7 @@ func TestAnalyzer(t *testing.T) {
 		"crosspkgdi/infra",
 		"crosspkgdi/usecase",
 		"ifacehigherorder",
-		"falsenegative",
+		"compositelit",
 	)
 }
 

--- a/goexhauerrors/analyzer_test.go
+++ b/goexhauerrors/analyzer_test.go
@@ -45,6 +45,7 @@ func TestAnalyzer(t *testing.T) {
 		"crosspkgdi/infra",
 		"crosspkgdi/usecase",
 		"ifacehigherorder",
+		"falsenegative",
 	)
 }
 

--- a/goexhauerrors/detector/detector.go
+++ b/goexhauerrors/detector/detector.go
@@ -170,11 +170,7 @@ func isErrorOrImplementsError(t types.Type) bool {
 	}
 	// Also check pointer to the type
 	ptrType := types.NewPointer(t)
-	if types.Implements(ptrType, errorInterface) {
-		return true
-	}
-
-	return false
+	return types.Implements(ptrType, errorInterface)
 }
 
 // isCallSentinelInit checks if the expression is a function call sentinel init.
@@ -222,11 +218,7 @@ func isErrorCompositeLiteral(pass *analysis.Pass, expr ast.Expr) bool {
 		return true
 	}
 	ptrType := types.NewPointer(litType)
-	if types.Implements(ptrType, errorInterface) {
-		return true
-	}
-
-	return false
+	return types.Implements(ptrType, errorInterface)
 }
 
 // isErrorsNewCall checks if the call is errors.New().

--- a/goexhauerrors/testdata/src/compositelit/compositelit.go
+++ b/goexhauerrors/testdata/src/compositelit/compositelit.go
@@ -1,4 +1,4 @@
-package falsenegative
+package compositelit
 
 import (
 	"errors"
@@ -10,7 +10,7 @@ import (
 // Exported custom error type with struct literal sentinels
 // =============================================================================
 
-type HTTPError struct { // want HTTPError:`falsenegative.HTTPError`
+type HTTPError struct { // want HTTPError:`compositelit.HTTPError`
 	Code    int
 	Message string
 }
@@ -23,7 +23,7 @@ var ErrNotFound = &HTTPError{Code: 404, Message: "not found"}
 var ErrBadRequest = &HTTPError{Code: 400, Message: "bad request"}
 
 // GetUser returns ErrNotFound (struct literal sentinel, NOT errors.New)
-func GetUser(id string) (*string, error) { // want GetUser:`\[falsenegative.HTTPError\]`
+func GetUser(id string) (*string, error) { // want GetUser:`\[compositelit.HTTPError\]`
 	if id == "" {
 		return nil, ErrNotFound
 	}
@@ -32,7 +32,7 @@ func GetUser(id string) (*string, error) { // want GetUser:`\[falsenegative.HTTP
 }
 
 // GetOrder returns ErrNotFound or ErrBadRequest
-func GetOrder(id string) (*string, error) { // want GetOrder:`\[falsenegative.HTTPError\]`
+func GetOrder(id string) (*string, error) { // want GetOrder:`\[compositelit.HTTPError\]`
 	if id == "" {
 		return nil, ErrNotFound
 	}
@@ -45,7 +45,7 @@ func GetOrder(id string) (*string, error) { // want GetOrder:`\[falsenegative.HT
 
 // BadCallerStructLiteral does not check for HTTPError type
 func BadCallerStructLiteral() {
-	_, err := GetUser("") // want "missing errors.Is check for falsenegative.HTTPError"
+	_, err := GetUser("") // want "missing errors.Is check for compositelit.HTTPError"
 	if err != nil {
 		println(err.Error())
 	}
@@ -77,7 +77,7 @@ var ErrUnauthorized = &httpErr{statusCode: 401}
 var ErrForbidden = &httpErr{statusCode: 403}
 
 // Authenticate returns ErrUnauthorized or ErrForbidden
-func Authenticate(token string) error { // want Authenticate:`\[falsenegative.httpErr\]`
+func Authenticate(token string) error { // want Authenticate:`\[compositelit.httpErr\]`
 	if token == "" {
 		return ErrUnauthorized
 	}
@@ -89,7 +89,7 @@ func Authenticate(token string) error { // want Authenticate:`\[falsenegative.ht
 
 // BadCallerUnexportedType does not check at all
 func BadCallerUnexportedType() {
-	err := Authenticate("") // want "missing errors.Is check for falsenegative.httpErr"
+	err := Authenticate("") // want "missing errors.Is check for compositelit.httpErr"
 	if err != nil {
 		println(err.Error())
 	}
@@ -110,14 +110,14 @@ func GoodCallerUnexportedType() {
 // This was a false negative before the composite literal detection fix.
 // =============================================================================
 
-var ErrTypedAsError error = &HTTPError{Code: 500, Message: "internal"} // want ErrTypedAsError:`falsenegative.ErrTypedAsError`
+var ErrTypedAsError error = &HTTPError{Code: 500, Message: "internal"} // want ErrTypedAsError:`compositelit.ErrTypedAsError`
 
-func GetInternalError() error { // want GetInternalError:`\[falsenegative.ErrTypedAsError\]`
+func GetInternalError() error { // want GetInternalError:`\[compositelit.ErrTypedAsError\]`
 	return ErrTypedAsError
 }
 
 func BadCallerErrorTyped() {
-	err := GetInternalError() // want "missing errors.Is check for falsenegative.ErrTypedAsError"
+	err := GetInternalError() // want "missing errors.Is check for compositelit.ErrTypedAsError"
 	if err != nil {
 		println(err.Error())
 	}
@@ -159,7 +159,7 @@ func BadCallerCustomInit() {
 // The linter reports at type level (HTTPError), not variable level.
 // =============================================================================
 
-func GetOrderBad(id string) error { // want GetOrderBad:`\[falsenegative.HTTPError\]`
+func GetOrderBad(id string) error { // want GetOrderBad:`\[compositelit.HTTPError\]`
 	if id == "" {
 		return ErrNotFound
 	}
@@ -182,9 +182,9 @@ func CallerChecksSameType() {
 // Pattern 6: Sentinel + struct literal sentinel mix
 // =============================================================================
 
-var ErrSentinel = errors.New("sentinel") // want ErrSentinel:`falsenegative.ErrSentinel`
+var ErrSentinel = errors.New("sentinel") // want ErrSentinel:`compositelit.ErrSentinel`
 
-func MixedReturns(flag int) error { // want MixedReturns:`\[falsenegative.ErrSentinel, falsenegative.HTTPError\]`
+func MixedReturns(flag int) error { // want MixedReturns:`\[compositelit.ErrSentinel, compositelit.HTTPError\]`
 	switch flag {
 	case 1:
 		return ErrSentinel
@@ -196,14 +196,14 @@ func MixedReturns(flag int) error { // want MixedReturns:`\[falsenegative.ErrSen
 }
 
 func BadCallerMixed() {
-	err := MixedReturns(1) // want "missing errors.Is check for falsenegative.ErrSentinel" "missing errors.Is check for falsenegative.HTTPError"
+	err := MixedReturns(1) // want "missing errors.Is check for compositelit.ErrSentinel" "missing errors.Is check for compositelit.HTTPError"
 	if err != nil {
 		println(err.Error())
 	}
 }
 
 func PartialCallerMixed() {
-	err := MixedReturns(1) // want "missing errors.Is check for falsenegative.HTTPError"
+	err := MixedReturns(1) // want "missing errors.Is check for compositelit.HTTPError"
 	if errors.Is(err, ErrSentinel) {
 		println("sentinel")
 	}
@@ -240,7 +240,7 @@ func BadCallerWrap() {
 // =============================================================================
 
 func CallerTypeAssertionDirect() {
-	_, err := GetUser("") // want "missing errors.Is check for falsenegative.HTTPError"
+	_, err := GetUser("") // want "missing errors.Is check for compositelit.HTTPError"
 	if _, ok := err.(*HTTPError); ok {
 		println("http error")
 	}

--- a/goexhauerrors/testdata/src/falsenegative/falsenegative.go
+++ b/goexhauerrors/testdata/src/falsenegative/falsenegative.go
@@ -1,0 +1,247 @@
+package falsenegative
+
+import (
+	"errors"
+	"fmt"
+)
+
+// =============================================================================
+// Pattern 1: Sentinel error with struct literal init (not errors.New)
+// Exported custom error type with struct literal sentinels
+// =============================================================================
+
+type HTTPError struct { // want HTTPError:`falsenegative.HTTPError`
+	Code    int
+	Message string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.Code, e.Message)
+}
+
+var ErrNotFound = &HTTPError{Code: 404, Message: "not found"}
+var ErrBadRequest = &HTTPError{Code: 400, Message: "bad request"}
+
+// GetUser returns ErrNotFound (struct literal sentinel, NOT errors.New)
+func GetUser(id string) (*string, error) { // want GetUser:`\[falsenegative.HTTPError\]`
+	if id == "" {
+		return nil, ErrNotFound
+	}
+	name := "user"
+	return &name, nil
+}
+
+// GetOrder returns ErrNotFound or ErrBadRequest
+func GetOrder(id string) (*string, error) { // want GetOrder:`\[falsenegative.HTTPError\]`
+	if id == "" {
+		return nil, ErrNotFound
+	}
+	if id == "bad" {
+		return nil, ErrBadRequest
+	}
+	name := "order"
+	return &name, nil
+}
+
+// BadCallerStructLiteral does not check for HTTPError type
+func BadCallerStructLiteral() {
+	_, err := GetUser("") // want "missing errors.Is check for falsenegative.HTTPError"
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+// GoodCallerStructLiteral checks with errors.As
+func GoodCallerStructLiteral() {
+	_, err := GetUser("")
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		println("http error:", httpErr.Code)
+	}
+}
+
+// =============================================================================
+// Pattern 2: Exported variable of unexported custom error type (Echo pattern)
+// The type is unexported, but the variable is exported
+// =============================================================================
+
+type httpErr struct {
+	statusCode int
+}
+
+func (e *httpErr) Error() string {
+	return fmt.Sprintf("status: %d", e.statusCode)
+}
+
+var ErrUnauthorized = &httpErr{statusCode: 401}
+var ErrForbidden = &httpErr{statusCode: 403}
+
+// Authenticate returns ErrUnauthorized or ErrForbidden
+func Authenticate(token string) error { // want Authenticate:`\[falsenegative.httpErr\]`
+	if token == "" {
+		return ErrUnauthorized
+	}
+	if token == "invalid" {
+		return ErrForbidden
+	}
+	return nil
+}
+
+// BadCallerUnexportedType does not check at all
+func BadCallerUnexportedType() {
+	err := Authenticate("") // want "missing errors.Is check for falsenegative.httpErr"
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+// GoodCallerUnexportedType checks via errors.As
+func GoodCallerUnexportedType() {
+	err := Authenticate("")
+	var he *httpErr
+	if errors.As(err, &he) {
+		println("status:", he.statusCode)
+	}
+}
+
+// =============================================================================
+// Pattern 3: error-typed variable holding struct literal
+// The variable is declared as `error` type, not the concrete type
+// This was a false negative before the composite literal detection fix.
+// =============================================================================
+
+var ErrTypedAsError error = &HTTPError{Code: 500, Message: "internal"} // want ErrTypedAsError:`falsenegative.ErrTypedAsError`
+
+func GetInternalError() error { // want GetInternalError:`\[falsenegative.ErrTypedAsError\]`
+	return ErrTypedAsError
+}
+
+func BadCallerErrorTyped() {
+	err := GetInternalError() // want "missing errors.Is check for falsenegative.ErrTypedAsError"
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+func GoodCallerErrorTyped() {
+	err := GetInternalError()
+	if errors.Is(err, ErrTypedAsError) {
+		println("typed as error")
+	}
+}
+
+// =============================================================================
+// Pattern 4: Custom constructor function (not errors.New directly)
+// This is a known limitation - custom constructors are not recognized.
+// =============================================================================
+
+func newSentinelError(msg string) error {
+	return errors.New(msg)
+}
+
+var ErrCustomInit = newSentinelError("custom initialized error")
+
+func GetCustomError() error {
+	return ErrCustomInit
+}
+
+// This is NOT detected - known limitation.
+// ErrCustomInit is created by a custom constructor, not errors.New or composite literal.
+func BadCallerCustomInit() {
+	err := GetCustomError()
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+// =============================================================================
+// Pattern 5: Multiple sentinels of the same custom type
+// The linter reports at type level (HTTPError), not variable level.
+// =============================================================================
+
+func GetOrderBad(id string) error { // want GetOrderBad:`\[falsenegative.HTTPError\]`
+	if id == "" {
+		return ErrNotFound
+	}
+	if id == "bad" {
+		return ErrBadRequest
+	}
+	return nil
+}
+
+// Caller checks HTTPError type - this satisfies the linter
+func CallerChecksSameType() {
+	err := GetOrderBad("")
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		println("http error:", httpErr.Code)
+	}
+}
+
+// =============================================================================
+// Pattern 6: Sentinel + struct literal sentinel mix
+// =============================================================================
+
+var ErrSentinel = errors.New("sentinel") // want ErrSentinel:`falsenegative.ErrSentinel`
+
+func MixedReturns(flag int) error { // want MixedReturns:`\[falsenegative.ErrSentinel, falsenegative.HTTPError\]`
+	switch flag {
+	case 1:
+		return ErrSentinel
+	case 2:
+		return ErrNotFound
+	default:
+		return nil
+	}
+}
+
+func BadCallerMixed() {
+	err := MixedReturns(1) // want "missing errors.Is check for falsenegative.ErrSentinel" "missing errors.Is check for falsenegative.HTTPError"
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+func PartialCallerMixed() {
+	err := MixedReturns(1) // want "missing errors.Is check for falsenegative.HTTPError"
+	if errors.Is(err, ErrSentinel) {
+		println("sentinel")
+	}
+}
+
+// =============================================================================
+// Pattern 7: Error wrapping method (like Echo's ErrBadRequest.Wrap(err))
+// This is a known limitation - the linter cannot trace fmt.Errorf("%w", receiver)
+// to discover the receiver's concrete error type.
+// =============================================================================
+
+func (e *HTTPError) Wrap(inner error) error {
+	return fmt.Errorf("%w: %v", e, inner)
+}
+
+func BindJSON() error {
+	return ErrBadRequest.Wrap(fmt.Errorf("invalid json"))
+}
+
+// Not detected - known limitation. The linter can't trace through
+// fmt.Errorf's %w wrapping of a method receiver.
+func BadCallerWrap() {
+	err := BindJSON()
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+// =============================================================================
+// Pattern 8: Type assertion pattern
+// Direct type assertions (_, ok := err.(*Type)) are NOT recognized as checks.
+// Only errors.Is, errors.As, direct == comparison, and type switch are supported.
+// This is a known limitation.
+// =============================================================================
+
+func CallerTypeAssertionDirect() {
+	_, err := GetUser("") // want "missing errors.Is check for falsenegative.HTTPError"
+	if _, ok := err.(*HTTPError); ok {
+		println("http error")
+	}
+}


### PR DESCRIPTION
## Summary

- Fix false negative where `var Err error = &HTTPError{...}` (error interface-typed variable initialized with composite literal) was not detected as a sentinel error
- Add `isErrorCompositeLiteral()` to recognize `&Type{}` and `Type{}` composite literal patterns in sentinel detection
- Add `isErrorOrImplementsError()` to check if a type implements the error interface, not just if it IS the error interface
- Avoid duplicate diagnostics: composite literal sentinels with concrete types (e.g., `*HTTPError`) are detected at type level via SSA's MakeInterface, while only error interface-typed vars are added to `LocalErrs.Vars`
- Add comprehensive test file (`falsenegative/falsenegative.go`) covering 8 false negative patterns

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New `falsenegative` test package verifies:
  - Pattern 3 fix: `var Err error = &HTTPError{...}` now correctly detected
  - No regressions in Patterns 1, 2, 5, 6 (type-level detection unchanged)
  - Known limitations documented with correct annotations (Patterns 4, 7, 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)